### PR TITLE
Fix thumbs of CMYK PDFs for IE (credit to Serhiy)

### DIFF
--- a/includes/pdf.process.inc
+++ b/includes/pdf.process.inc
@@ -133,6 +133,7 @@ function islandora_pdf_create_jpg_derivative($file_uri, $dsid,  $width, $height)
   $dest = drupal_realpath($temp);
   $args['quality'] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
   $args['previewsize'] = '-resize ' . escapeshellarg("{$width}x{$height}");
+  $args['colors'] = '-colorspace RGB';
   $context = array(
     'source' => $source,
     'destination' => $dest,


### PR DESCRIPTION
Some pdf thumbnails appeared as a red "X" in IE if the pdf was using the CMYK colorspace. 
This fix was authored by Serhiy, described at: 
https://groups.google.com/forum/?fromgroups=#!topic/islandora/nulnlsscWZk
