### PR TITLE
Not showing broken img when lacking access to PREVIEW

### DIFF
--- a/theme/islandora-pdf.tpl.php
+++ b/theme/islandora-pdf.tpl.php
@@ -14,9 +14,9 @@
       <div class="islandora-pdf-content">
         <?php print $islandora_content; ?>
       </div>
-      <?php if (isset($islandora_download_link)): ?>
-        <?php print $islandora_download_link; ?>
-      <?php endif; ?>
+    <?php endif; ?>
+    <?php if (isset($islandora_download_link)): ?>
+      <?php print $islandora_download_link; ?>
     <?php endif; ?>
   </div>
   <div class="islandora-pdf-metadata">

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -66,7 +66,7 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
       $variables['islandora_thumbnail_img'] = theme('image', $params);
     }
     // Preview image + link.
-    if (isset($islandora_object['PREVIEW'])) {
+    if (isset($islandora_object['PREVIEW']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['PREVIEW'])) {
       $preview_url = url("islandora/object/{$islandora_object->id}/datastream/PREVIEW/view");
       $params = array(
         'title' => $islandora_object->label,
@@ -74,13 +74,12 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
       );
       $variables['islandora_preview_img'] = theme('image', $params);
       $variables['islandora_content'] = l($variables['islandora_preview_img'], $variables['islandora_full_url'], array('html' => TRUE));
-      // Sanitize this object name a bit.
-      $sanitized_label = preg_replace('/[^A-Za-z0-9_\-]|\.pdf$/', '_', $islandora_object->label);
-      $download_url = 'islandora/object/' . $islandora_object->id . '/datastream/OBJ/download/' . $sanitized_label . '.pdf';
-      $download_text = t("Download pdf");
-      $variables['islandora_download_link'] = l($download_text, $download_url, array('attributes' => array('class' => array('islandora-pdf-link'))));
     }
-
+    // Sanitize this object name a bit and provide download link.
+    $sanitized_label = preg_replace('/[^A-Za-z0-9_\-]|\.pdf$/', '_', $islandora_object->label);
+    $download_url = 'islandora/object/' . $islandora_object->id . '/datastream/OBJ/download/' . $sanitized_label . '.pdf';
+    $download_text = t("Download pdf");
+    $variables['islandora_download_link'] = l($download_text, $download_url, array('attributes' => array('class' => array('islandora-pdf-link'))));
   }
 }
 


### PR DESCRIPTION
**Jira:** [ISLANDORA-1550](https://jira.duraspace.org/browse/ISLANDORA-1550)
# What does this Pull Request do?

Prevents the PDF solution pack from displaying a broken image when a user lacks access to the PREVIEW DS.
# How should this be tested?

Ingest a PDF.
XACML the PREVIEW DS.
Goto the object view.
Before the pull a broken img is displayed.
After the pull no broken img is displayed.

---

William Panting
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
