### PR TITLE
Added datastream access check and datastream exists check on OBJ pdf download link

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -82,7 +82,6 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
       );
 
       $variables['islandora_preview_img'] = theme('image', $params);
-      $variables['islandora_full_url'] = NULL;
       $variables['islandora_content'] = isset($variables['islandora_full_url']) ? l($variables['islandora_preview_img'], $variables['islandora_full_url'], array('html' => TRUE)) :
         $variables['islandora_preview_img'];
     }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -52,10 +52,17 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
   }
   else {
     // Full size url.
-    if (isset($islandora_object['OBJ'])) {
+    if (isset($islandora_object['OBJ']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['OBJ'])) {
       $full_size_url = url("islandora/object/{$islandora_object->id}/datastream/OBJ/view", array('absolute' => TRUE));
       $variables['islandora_full_url'] = $full_size_url;
+
+      // Sanitize this object name a bit and provide download link.
+      $sanitized_label = preg_replace('/[^A-Za-z0-9_\-]|\.pdf$/', '_', $islandora_object->label);
+      $download_url = 'islandora/object/' . $islandora_object->id . '/datastream/OBJ/download/' . $sanitized_label . '.pdf';
+      $download_text = t("Download pdf");
+      $variables['islandora_download_link'] = l($download_text, $download_url, array('attributes' => array('class' => array('islandora-pdf-link'))));
     }
+
     // Thumbnail.
     if (isset($islandora_object['TN'])) {
       $thumbnail_size_url = url("islandora/object/{$islandora_object->id}/datastream/TN/view");
@@ -65,6 +72,7 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
       );
       $variables['islandora_thumbnail_img'] = theme('image', $params);
     }
+
     // Preview image + link.
     if (isset($islandora_object['PREVIEW']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['PREVIEW'])) {
       $preview_url = url("islandora/object/{$islandora_object->id}/datastream/PREVIEW/view");
@@ -75,11 +83,6 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
       $variables['islandora_preview_img'] = theme('image', $params);
       $variables['islandora_content'] = l($variables['islandora_preview_img'], $variables['islandora_full_url'], array('html' => TRUE));
     }
-    // Sanitize this object name a bit and provide download link.
-    $sanitized_label = preg_replace('/[^A-Za-z0-9_\-]|\.pdf$/', '_', $islandora_object->label);
-    $download_url = 'islandora/object/' . $islandora_object->id . '/datastream/OBJ/download/' . $sanitized_label . '.pdf';
-    $download_text = t("Download pdf");
-    $variables['islandora_download_link'] = l($download_text, $download_url, array('attributes' => array('class' => array('islandora-pdf-link'))));
   }
 }
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -80,8 +80,11 @@ function islandora_pdf_preprocess_islandora_pdf(&$variables) {
         'title' => $islandora_object->label,
         'path' => $preview_url,
       );
+
       $variables['islandora_preview_img'] = theme('image', $params);
-      $variables['islandora_content'] = l($variables['islandora_preview_img'], $variables['islandora_full_url'], array('html' => TRUE));
+      $variables['islandora_full_url'] = NULL;
+      $variables['islandora_content'] = isset($variables['islandora_full_url']) ? l($variables['islandora_preview_img'], $variables['islandora_full_url'], array('html' => TRUE)) :
+        $variables['islandora_preview_img'];
     }
   }
 }


### PR DESCRIPTION

**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1882)

# What does this Pull Request do?

Adds a datastream access check for pdf download links, and ensure the datastream exists in the islandora_pdf_preprocess_islandora_pdf preprocess function.

# What's new?
Adding the datastream access check and datastream exists check is done to prevent a download link to a non existent/non accessible datastream (OBJ, in this case).

Example:
* Added DSID access check
* Added OBJ exists check

# How should this be tested?
- Create object with the PDF CModel
- Add PDF to said object and ingest
- view object (download link exists)
- delete the OBJ datastream
- view object (download link is not shown)

This should have very little impact on existing installations, however if the new datastream access check fails on the pdf's OBJ datastream or the OBJ datastream does not exist, the 'islandora_download_link' variable will not be present in the template var's further down the processing chain. This should be a non issue, as the standard practice when working in template_preprocessing function implementations is to check if the variable exists first.

# Interested parties
Tag @Islandora/7-x-1-x-committers
