### PR TITLE
screenshot adds the display for the gs path 7.x-1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Configure thumbnail and preview image sizes, and set the path for `pdftotext` and `gs` if extract text stream and create PDFA derivative are selected, respectively, in Administration » Islandora »  Solution pack configuration »  PDF Solution Pack (admin/islandora/solution_pack_config/pdf).
 
-![Configuration](https://raw.githubusercontent.com/dmoses/islandora_screenshots/master/pdf_sp_config.jpg)
+![Configuration](https://user-images.githubusercontent.com/2738244/39442606-cdd9747e-4c7f-11e8-9dfa-d62f61ac3f76.png)
 
 ## Documentation
 


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?
Replaces screenshot. The new screenshots shows that the GS path is editable. 

# What's new?
Switches the "confirmed" status for GS to show that the GS path is editable. 

# How should this be tested?
Look at admin/islandora/solution_pack_config/pdf to verify 

# Additional Notes:
N/A

# Interested parties
@Islandora/7-x-1-x-committers
