### PR TITLE
ISLANDORA-2407: Selectable colorspace for PREVIEW/TN

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -151,6 +151,19 @@ function islandora_pdf_admin($form, &$form_state) {
     '#size' => 5,
   );
 
+  $form['islandora_pdf_thumbnail_fieldset']['islandora_pdf_thumbnail_colorspace'] = array(
+    '#type' => 'select',
+    '#title' => t('Colorspace'),
+    '#options' => array(
+      'sRGB' => t('sRGB'),
+      'RGB' => t('RGB'),
+      'CMYK' => t('CMYK'),
+      'Gray' => t('Grayscale'),
+    ),
+    '#description' => t('The colorspace for the derived thumbnail.'),
+    '#default_value' => variable_get('islandora_pdf_thumbnail_colorspace', 'sRGB'),
+  );
+
   $form['islandora_pdf_preview_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Preview image'),
@@ -173,6 +186,19 @@ function islandora_pdf_admin($form, &$form_state) {
     '#element_validate' => array('element_validate_number'),
     '#default_value' => variable_get('islandora_pdf_preview_height', 700),
     '#size' => 5,
+  );
+
+  $form['islandora_pdf_preview_fieldset']['islandora_pdf_preview_colorspace'] = array(
+    '#type' => 'select',
+    '#title' => t('Colorspace'),
+    '#options' => array(
+      'sRGB' => t('sRGB'),
+      'RGB' => t('RGB'),
+      'CMYK' => t('CMYK'),
+      'Gray' => t('Grayscale'),
+    ),
+    '#description' => t('The colorspace for the derived preview.'),
+    '#default_value' => variable_get('islandora_pdf_preview_colorspace', 'sRGB'),
   );
 
   module_load_include('inc', 'islandora', 'includes/solution_packs');

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -43,7 +43,7 @@ function islandora_pdf_add_tn_derivative(AbstractObject $object, $force = FALSE)
     $height = variable_get('islandora_pdf_thumbnail_height', 200);
     $colorspace = variable_get('islandora_pdf_thumbnail_colorspace', 'sRGB');
     $file_uri = islandora_pdf_get_derivative_source_as_unmanaged_file($object);
-    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $colorspace, $force);
+    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $force, $colorspace);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -228,7 +228,7 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
     $height = variable_get('islandora_pdf_preview_height', 700);
     $colorspace = variable_get('islandora_pdf_preview_colorspace', 'sRGB');
     $file_uri = islandora_pdf_get_derivative_source_as_unmanaged_file($object);
-    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $colorspace, $force);
+    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $force, $colorspace);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -247,10 +247,10 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
- * @param string $colorspace
- *   The colorspace for the derived datastream.
  * @param bool $force
  *   Whether the derivative generation is being forced or not.
+ * @param string $colorspace
+ *   The colorspace for the derived datastream.
  *
  * @return array|null
  *   An array describing the outcome of adding the JPG derivative or NULL if no
@@ -258,7 +258,7 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
  *
  * @see hook_islandora_derivative()
  */
-function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $colorspace, $force) {
+function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $force, $colorspace = NULL) {
   if (!isset($object[$dsid]) || (isset($object[$dsid]) && $force === TRUE)) {
     if (!isset($object['OBJ'])) {
       return islandora_pdf_missing_obj_datastream($object->id);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -319,7 +319,7 @@ function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $ds
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
- * @param int $colorspace
+ * @param string $colorspace
  *   The colorspace for the derived datastream.
  *
  * @return string|array

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -327,7 +327,13 @@ function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $ds
  *
  * @see hook_islandora_derivative()
  */
-function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace) {
+function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace = NULL) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  if (is_null($colorspace)) {
+    $colorspace = 'sRGB';
+    $message = islandora_deprecated('7.x-1.12', t('The colorspace now needs to be specified in islandora_pdf_create_jpg_derivative'));
+    trigger_error(filter_xss($message), E_USER_DEPRECATED);
+  }
   $source = drupal_realpath($file_uri) . '[0]';
   $matches = array();
   // Get the base name of the source file.

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -41,8 +41,9 @@ function islandora_pdf_add_tn_derivative(AbstractObject $object, $force = FALSE)
   if ($force || !isset($object['TN'])) {
     $width = variable_get('islandora_pdf_thumbnail_width', 200);
     $height = variable_get('islandora_pdf_thumbnail_height', 200);
+    $colorspace = variable_get('islandora_pdf_thumbnail_colorspace', 'sRGB');
     $file_uri = islandora_pdf_get_derivative_source_as_unmanaged_file($object);
-    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $force);
+    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $colorspace, $force);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -225,8 +226,9 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
   if ($force || !isset($object['PREVIEW'])) {
     $width = variable_get('islandora_pdf_preview_width', 500);
     $height = variable_get('islandora_pdf_preview_height', 700);
+    $colorspace = variable_get('islandora_pdf_preview_colorspace', 'sRGB');
     $file_uri = islandora_pdf_get_derivative_source_as_unmanaged_file($object);
-    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $force);
+    $results = islandora_pdf_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $colorspace, $force);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -245,6 +247,8 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
+ * @param string $colorspace
+ *   The colorspace for the derived datastream.
  * @param bool $force
  *   Whether the derivative generation is being forced or not.
  *
@@ -254,12 +258,12 @@ function islandora_pdf_add_preview_derivative(AbstractObject $object, $force = F
  *
  * @see hook_islandora_derivative()
  */
-function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $force) {
+function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $colorspace, $force) {
   if (!isset($object[$dsid]) || (isset($object[$dsid]) && $force === TRUE)) {
     if (!isset($object['OBJ'])) {
       return islandora_pdf_missing_obj_datastream($object->id);
     }
-    $derivative_file_uri = islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height);
+    $derivative_file_uri = islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace);
     file_unmanaged_delete($file_uri);
     // Receive a valid file URI to add or an error message otherwise.
     if (!is_array($derivative_file_uri) && file_valid_uri($derivative_file_uri)) {
@@ -315,13 +319,15 @@ function islandora_pdf_add_jpg_derivative(AbstractObject $object, $file_uri, $ds
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
+ * @param int $colorspace
+ *   The colorspace for the derived datastream.
  *
  * @return string|array
  *   A URI to the generated derivative if successful, error message otherwise.
  *
  * @see hook_islandora_derivative()
  */
-function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height) {
+function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace) {
   $source = drupal_realpath($file_uri) . '[0]';
   $matches = array();
   // Get the base name of the source file.
@@ -330,7 +336,7 @@ function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height) 
   $dest = drupal_realpath($temp);
   $args['quality'] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
   $args['previewsize'] = '-resize ' . escapeshellarg("{$width}x{$height}");
-  $args['colors'] = '-colorspace RGB';
+  $args['colors'] = "-colorspace {$colorspace}";
   $args['flatten'] = '-flatten';
   $context = array(
     'source' => $source,

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -21,6 +21,20 @@ function islandora_pdf_install() {
 function islandora_pdf_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_pdf', 'uninstall');
+  $variables = array(
+    'islandora_pdf_path_to_pdftotext',
+    'islandora_pdf_path_to_gs',
+    'islandora_pdf_allow_text_upload',
+    'islandora_pdf_create_fulltext',
+    'islandora_pdf_create_pdfa',
+    'islandora_pdf_thumbnail_width',
+    'islandora_pdf_thumbnail_height',
+    'islandora_pdf_thumbnail_colorspace',
+    'islandora_pdf_preview_width',
+    'islandora_pdf_preview_height',
+    'islandora_pdf_preview_colorspace',
+  );
+  array_walk($variables, 'variable_del');
 }
 
 /**
@@ -30,5 +44,5 @@ function islandora_pdf_update_7001(&$sandbox) {
   variable_set('islandora_pdf_preview_colorspace', 'RGB');
   variable_set('islandora_pdf_thumbnail_colorspace', 'RGB');
   $t = get_t();
-  return $t('Set colorspace configuration to RBG to maintain existing functionality.');
+  return $t('Set colorspace configuration to RBG to maintain existing profile.');
 }

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -22,3 +22,13 @@ function islandora_pdf_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_pdf', 'uninstall');
 }
+
+/**
+ * Maintain existing RGB colorspace profile configuration.
+ */
+function islandora_pdf_update_7001(&$sandbox) {
+  variable_set('islandora_pdf_preview_colorspace', 'RGB');
+  variable_set('islandora_pdf_thumbnail_colorspace', 'RGB');
+  $t = get_t();
+  return $t('Set colorspace configuration to RBG to maintain existing functionality.');
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2407

# What does this Pull Request do?

Adds a dropdown to the solution pack config UI which allows users to select from a list of colorspaces to use when creating TN/PREVIEW derivatives. The intention of this pull is to allow users to choose a more reliable/consistent colorspace profile for PDF derivatives. The currently hardcoded RGB colorspace appears to create substantially darker derivatives compared to their source file.

# What's new?

* Dropdown select to configure colorspace configuration for PREVIEW & TN derivative datastreams in the SP admin configuration UI
* Profiles include RBG, sRGB, CYMK & Grayscale
* Update hook preserves existing colorspace for older systems (RGB)

# How should this be tested?

Ingest a test PDF object and confirm that the color profiles have been properly applied for both the TN and PREVIEW datastreams by downloading and then running `identify -format %[colorspace] /path/to/file`.

Also confirm that the update hook properly applies older colorspace configuration.

# Interested parties
@Islandora/7-x-1-x-committers 👋 
