### PR TITLE
7.x deprecated dUseCIEColor

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -76,7 +76,9 @@ function islandora_pdf_admin($form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t("Use dUseCIEColor when generating PDFA datastream."),
     '#description' => t("As of GhostScript 9.11, the use of the dUseCIEColor switch is not recommended. See https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html.
-                          </br>Version installed: $version[0]."),
+                          </br>Version installed: !version.", array(
+                            '!version' => $version[0],
+                          )),
     '#default_value' => variable_get('islandora_pdf_use_duseciecolor', FALSE),
   );
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -9,7 +9,6 @@
  * Admin form function.
  */
 function islandora_pdf_admin($form, &$form_state) {
-
   if (isset($form_state['values']['islandora_pdf_path_to_pdftotext'])) {
     $islandora_pdf_path_to_pdftotext = $form_state['values']['islandora_pdf_path_to_pdftotext'];
   }
@@ -68,6 +67,17 @@ function islandora_pdf_admin($form, &$form_state) {
     '#title' => t("Create PDF/A archival derivative from PDF"),
     '#description' => t("Create a PDF/A version of any uploaded PDF. PDF/A is a restrictive standard that prohibits more easily broken components of the PDF spec, such as fillable forms and DRM. The PDF/A derivative will not be used for display. Requires ghostscript to be installed on the server."),
     '#default_value' => variable_get('islandora_pdf_create_pdfa', FALSE),
+  );
+
+  $executable = variable_get('islandora_pdf_path_to_gs', '/usr/bin/gs');
+  $version_command = "$executable --version";
+  exec($version_command, $version);
+  $form['islandora_pdf_url_fieldset']['islandora_pdf_use_duseciecolor'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Use dUseCIEColor when generating PDFA datastream."),
+    '#description' => t("As of GhostScript 9.11, the use of the dUseCIEColor switch is not recommended. See https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html.
+                          </br>Version installed: $version[0]."),
+    '#default_value' => variable_get('islandora_pdf_use_duseciecolor', FALSE),
   );
 
   $form['islandora_pdf_url_fieldset']['wrapper'] = array(

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -340,7 +340,9 @@ function islandora_pdf_create_jpg_derivative($file_uri, $dsid, $width, $height, 
   if (is_null($colorspace)) {
     $colorspace = 'sRGB';
     $message = islandora_deprecated('7.x-1.12', t('The colorspace now needs to be specified in islandora_pdf_create_jpg_derivative'));
+    // @codingStandardsIgnoreStart
     trigger_error(filter_xss($message), E_USER_DEPRECATED);
+    // @codingStandardsIgnoreEnd
   }
   $source = drupal_realpath($file_uri) . '[0]';
   $matches = array();

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -142,6 +142,7 @@ function islandora_pdf_add_fulltext_derivative(AbstractObject $object, $force = 
  */
 function islandora_pdf_add_pdfa_derivative(AbstractObject $object, $force = FALSE) {
   module_load_include('inc', 'islandora', 'includes/utilities');
+  $min_version = "9.11";
   if (!isset($object['OBJ'])) {
     return islandora_pdf_missing_obj_datastream($object->id);
   }
@@ -151,7 +152,18 @@ function islandora_pdf_add_pdfa_derivative(AbstractObject $object, $force = FALS
   $executable = variable_get('islandora_pdf_path_to_gs', '/usr/bin/gs');
   $temp = file_create_filename('pdfa.pdf', 'temporary://');
   $derivative_file_uri = drupal_realpath($temp);
-  $command = "$executable -dPDFA -dNOOUTERSAVE -dUseCIEColor -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
+
+  // XXX. As of Ghostscript version 9.11, the use of -dUseCIEColor is not
+  // recommended.
+  // see https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html.
+  $version_command = "$executable --version";
+  exec($version_command, $version);
+  if ($version[0] >= $min_version) {
+    $command = "$executable -dPDFA -dNOOUTERSAVE -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
+  }
+  else {
+    $command = "$executable -dPDFA -dNOOUTERSAVE -dUseCIEColor -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
+  }
   exec($command, $execout, $returncode);
   file_unmanaged_delete($file_uri);
   $success = ($returncode === 0);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -156,14 +156,14 @@ function islandora_pdf_add_pdfa_derivative(AbstractObject $object, $force = FALS
   // XXX. As of Ghostscript version 9.11, the use of -dUseCIEColor is not
   // recommended.
   // see https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html.
+  $use_ci_color = "-dUseCIEColor";
   $version_command = "$executable --version";
   exec($version_command, $version);
+
   if ($version[0] >= $min_version) {
-    $command = "$executable -dPDFA -dNOOUTERSAVE -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
+    $use_ci_color = "";
   }
-  else {
-    $command = "$executable -dPDFA -dNOOUTERSAVE -dUseCIEColor -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
-  }
+  $command = "$executable -dPDFA -dNOOUTERSAVE $use_ci_color -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
   exec($command, $execout, $returncode);
   file_unmanaged_delete($file_uri);
   $success = ($returncode === 0);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -142,7 +142,6 @@ function islandora_pdf_add_fulltext_derivative(AbstractObject $object, $force = 
  */
 function islandora_pdf_add_pdfa_derivative(AbstractObject $object, $force = FALSE) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $min_version = "9.11";
   if (!isset($object['OBJ'])) {
     return islandora_pdf_missing_obj_datastream($object->id);
   }
@@ -156,12 +155,9 @@ function islandora_pdf_add_pdfa_derivative(AbstractObject $object, $force = FALS
   // XXX. As of Ghostscript version 9.11, the use of -dUseCIEColor is not
   // recommended.
   // see https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html.
-  $use_ci_color = "-dUseCIEColor";
-  $version_command = "$executable --version";
-  exec($version_command, $version);
-
-  if ($version[0] >= $min_version) {
-    $use_ci_color = "";
+  $use_ci_color = "";
+  if (variable_get('islandora_pdf_use_duseciecolor', FALSE)) {
+    $use_ci_color = "-dUseCIEColor";
   }
   $command = "$executable -dPDFA -dNOOUTERSAVE $use_ci_color -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -o $derivative_file_uri -dPDFACompatibilityPolicy=1 $source ";
   exec($command, $execout, $returncode);

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -48,6 +48,18 @@ function islandora_pdf_update_7001(&$sandbox) {
   return $t('Set colorspace configuration to RBG to maintain existing profile.');
 }
 
-function islandora_pdf_update_7002(&$sandbox) {
-  variable_set('islandora_pdf_use_duseciecolor', FALSE);
+/**
+ * Set and maintain new dUseCIEColor switch variable.
+ */
+function islandora_pdf_update_7100(&$sandbox) {
+  $min_version = "9.11";
+  $executable = variable_get('islandora_pdf_path_to_gs', '/usr/bin/gs');
+  $version_command = "$executable --version";
+  exec($version_command, $installed_version);
+  if (version_compare($min_version, $installed_version[0], '>=')) {
+    variable_set('islandora_pdf_use_duseciecolor', FALSE);
+  }
+  else {
+    variable_set('islandora_pdf_use_duseciecolor', TRUE);
+  }
 }

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -47,3 +47,7 @@ function islandora_pdf_update_7001(&$sandbox) {
   $t = get_t();
   return $t('Set colorspace configuration to RBG to maintain existing profile.');
 }
+
+function islandora_pdf_update_7002(&$sandbox) {
+  variable_set('islandora_pdf_use_duseciecolor', FALSE);
+}

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -33,6 +33,7 @@ function islandora_pdf_uninstall() {
     'islandora_pdf_preview_width',
     'islandora_pdf_preview_height',
     'islandora_pdf_preview_colorspace',
+    'islandora_pdf_use_duseciecolor',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_pdf.install
+++ b/islandora_pdf.install
@@ -56,7 +56,7 @@ function islandora_pdf_update_7100(&$sandbox) {
   $executable = variable_get('islandora_pdf_path_to_gs', '/usr/bin/gs');
   $version_command = "$executable --version";
   exec($version_command, $installed_version);
-  if (version_compare($min_version, $installed_version[0], '>=')) {
+  if (version_compare($installed_version[0], $min_version, '>=')) {
     variable_set('islandora_pdf_use_duseciecolor', FALSE);
   }
   else {


### PR DESCRIPTION
**ISLANDORA-2432**: (https://jira.duraspace.org/browse/ISLANDORA-2432)

# What does this Pull Request do?
This pull request with allow the module to handle Ghostscript versions lower than 9.11, where the switch "-dUseCIEColor" is recommended not be used. See https://ghostscript.com/pipermail/gs-devel/2014-July/009693.html

# What's new?
When generating the PDF/A datastream, the -dUseCIEColor switch will be used based on the version of Ghostscript being used on the server. If the version is 9.11 or greater, the switch is not used.

# How should this be tested?
-- Using a version of Ghostscript < 9.11 and a version greater --
* Ensure that Create PDF/A archival derivative from PDF is enabled in PDF configuration. 
* Ingest a PDF that is composed mostly of images. 
* The object should be ingested normally and the PDFA datastream generated successfully.
* The view of the object should function as normal

# Interested parties
@Islandora/7-x-1-x-committers
@jonathangreen 
